### PR TITLE
Fix create_jam and update_jam commands

### DIFF
--- a/swablu/config.py
+++ b/swablu/config.py
@@ -153,6 +153,13 @@ def get_jam(dbcon, key):
     return json.loads(d['config'])
 
 
+def jam_exists(dbcon, key):
+    cursor = db_cursor(dbcon, dictionary=True, buffered=True)
+    sql = f"SELECT * FROM `{TABLE_NAME_JAM}` WHERE `key` = %s"
+    cursor.execute(sql, (key,))
+    return cursor.fetchone() is not None
+
+
 def create_jam(dbcon, jam_key, config):
     cursor = db_cursor(dbcon)
     sql = f"INSERT INTO {TABLE_NAME_JAM} (`key`, `config`) VALUES(%s, %s)"

--- a/swablu/specific/hacks_mgmnt.py
+++ b/swablu/specific/hacks_mgmnt.py
@@ -6,7 +6,7 @@ from discord import Message, TextChannel, Role, File
 from discord.ext.commands import RoleConverter
 from swablu.util import MiniCtx
 
-from swablu.config import database, TABLE_NAME, discord_client, get_jam, update_jam, create_jam, db_cursor
+from swablu.config import database, TABLE_NAME, discord_client, get_jam, jam_exists, update_jam, create_jam, db_cursor
 from swablu.web import invalidate_cache
 
 ALLOWED_ROLES = [
@@ -66,14 +66,7 @@ async def process_create_jam(message: Message, channel: TextChannel):
     jam_key = cmd_parts[1]
     jam_data = await message.attachments[0].read()
 
-    jam = None
-    try:
-        jam = get_jam(database, jam_key)
-    except Exception:
-        # ok we expect an error if there's nothing.
-        pass
-
-    if jam is not None:
+    if jam_exists(database, jam_key):
         raise ValueError("This jam already exists. Use !update_jam.")
 
     create_jam(database, jam_key, jam_data)
@@ -90,13 +83,7 @@ async def process_update_jam(message: Message, channel: TextChannel):
     jam_key = cmd_parts[1]
     jam_data = await message.attachments[0].read()
 
-    jam = None
-    try:
-        jam = get_jam(database, jam_key)
-    except Exception:
-        pass
-
-    if jam is None:
+    if not jam_exists(database, jam_key):
         raise ValueError("This jam does not exist. Use !create_jam.")
 
     update_jam(database, jam_key, jam_data)


### PR DESCRIPTION
The `create_jam` and and `update_jam` commands asssume that `get_jam()` throwing any exception means the requested jam does not exist, but this is incorrect. `get_jam()` can also throw an exception if the JSON of a jam is incorrect (and probably because of many other reasons too), which can lead to a situation where multiple jams are created with the same key or where `update_jam` cannot be used.

This change fixes this issue by adding a proper `jam_exists()` check.