### PR TITLE
Update 'Hack featured in' message

### DIFF
--- a/swablu/tpl/hack_in_list.html
+++ b/swablu/tpl/hack_in_list.html
@@ -13,7 +13,7 @@
         <div class="inner-content">
             {% if 'featured_jams' in hack %}
                 {% for fjam in hack['featured_jams'] %}
-                    <div class="featured feat-{{fjam['award']}}"><span>Featured in <a href="/jam/{{fjam['key']}}">"{{fjam['name']}}" Hack Jam</a>.</span></div>
+                    <div class="featured feat-{{fjam['award']}}"><span>Featured in <a href="/jam/{{fjam['key']}}">"{{fjam['name']}}" Hack Event</a>.</span></div>
                 {% end %}
             {% end %}
             {% if jam and jam['voting_enabled'] and key is not None %}


### PR DESCRIPTION
The message `Featured in "Hack of the Year 2022" Hack Jam` doesn't sound quite right since HotY isn't a jam. This change makes the message more generic so it applies to other events as well.