### PR TITLE
Hacks site changes

### DIFF
--- a/swablu/config.py
+++ b/swablu/config.py
@@ -190,21 +190,35 @@ def vote_jam(dbcon, jam_key, user_id, hack):
     cursor.close()
 
 
-def update_hack(dbcon, hack):
+def update_hack(dbcon, hack, silent=False):
     cursor = db_cursor(dbcon)
-    sql = f"UPDATE `{TABLE_NAME}` SET " \
-          f"`name` = %s," \
-          f"`description` = %s," \
-          f"`screenshot1` = %s," \
-          f"`screenshot2` = %s," \
-          f"`url_main` = %s," \
-          f"`url_discord` = %s," \
-          f"`url_download` = %s," \
-          f"`video` = %s," \
-          f"`hack_type` = %s," \
-          f"`message_id` = %s," \
-          f"`date_updated` = NOW()" \
-          f" WHERE id = %s"
+    if silent:
+        sql = f"UPDATE `{TABLE_NAME}` SET " \
+              f"`name` = %s," \
+              f"`description` = %s," \
+              f"`screenshot1` = %s," \
+              f"`screenshot2` = %s," \
+              f"`url_main` = %s," \
+              f"`url_discord` = %s," \
+              f"`url_download` = %s," \
+              f"`video` = %s," \
+              f"`hack_type` = %s," \
+              f"`message_id` = %s" \
+              f" WHERE id = %s"
+    else:
+        sql = f"UPDATE `{TABLE_NAME}` SET " \
+              f"`name` = %s," \
+              f"`description` = %s," \
+              f"`screenshot1` = %s," \
+              f"`screenshot2` = %s," \
+              f"`url_main` = %s," \
+              f"`url_discord` = %s," \
+              f"`url_download` = %s," \
+              f"`video` = %s," \
+              f"`hack_type` = %s," \
+              f"`message_id` = %s," \
+              f"`date_updated` = NOW()" \
+              f" WHERE id = %s"
     cursor.execute(sql, (
         hack['name'],
         hack['description'],

--- a/swablu/config.py
+++ b/swablu/config.py
@@ -192,33 +192,18 @@ def vote_jam(dbcon, jam_key, user_id, hack):
 
 def update_hack(dbcon, hack, silent=False):
     cursor = db_cursor(dbcon)
-    if silent:
-        sql = f"UPDATE `{TABLE_NAME}` SET " \
-              f"`name` = %s," \
-              f"`description` = %s," \
-              f"`screenshot1` = %s," \
-              f"`screenshot2` = %s," \
-              f"`url_main` = %s," \
-              f"`url_discord` = %s," \
-              f"`url_download` = %s," \
-              f"`video` = %s," \
-              f"`hack_type` = %s," \
-              f"`message_id` = %s" \
-              f" WHERE id = %s"
-    else:
-        sql = f"UPDATE `{TABLE_NAME}` SET " \
-              f"`name` = %s," \
-              f"`description` = %s," \
-              f"`screenshot1` = %s," \
-              f"`screenshot2` = %s," \
-              f"`url_main` = %s," \
-              f"`url_discord` = %s," \
-              f"`url_download` = %s," \
-              f"`video` = %s," \
-              f"`hack_type` = %s," \
-              f"`message_id` = %s," \
-              f"`date_updated` = NOW()" \
-              f" WHERE id = %s"
+    sql = f"UPDATE `{TABLE_NAME}` SET " \
+          f"`name` = %s," \
+          f"`description` = %s," \
+          f"`screenshot1` = %s," \
+          f"`screenshot2` = %s," \
+          f"`url_main` = %s," \
+          f"`url_discord` = %s," \
+          f"`url_download` = %s," \
+          f"`video` = %s," \
+          f"`hack_type` = %s," \
+          f"`message_id` = %s" if silent else f"`message_id` = %s,`date_updated` = NOW()" \
+          f" WHERE id = %s"
     cursor.execute(sql, (
         hack['name'],
         hack['description'],

--- a/swablu/roles.py
+++ b/swablu/roles.py
@@ -53,32 +53,24 @@ async def scan_roles():
 def get_hack_type_str(hack_type):
     if hack_type == "balance_hack_wip":
         return "Balance Hack (work in progress)"
-    if hack_type == "balance_hack_demo":
-        return "Balance Hack (with demo)"
     if hack_type == "balance_hack_mostly":
         return "Balance Hack (mostly finished)"
     if hack_type == "balance_hack":
         return "Balance Hack (finished)"
     if hack_type == "story_hack_wip":
         return "Story Hack (work in progress)"
-    if hack_type == "story_hack_demo":
-        return "Story Hack (with demo)"
     if hack_type == "story_hack_mostly":
         return "Story Hack (mostly finished)"
     if hack_type == "story_hack":
         return "Story Hack (finished)"
     if hack_type == "translation_wip":
         return "Translation (work in progress)"
-    if hack_type == "translation_demo":
-        return "Translation (with demo)"
     if hack_type == "translation_mostly":
         return "Translation (mostly finished)"
     if hack_type == "translation":
         return "Translation (finished)"
     if hack_type == "misc_hack_wip":
         return "Misc. Hack (work in progress)"
-    if hack_type == "misc_hack_demo":
-        return "Misc. Hack (with demo)"
     if hack_type == "misc_hack_mostly":
         return "Misc. Hack (mostly finished)"
     if hack_type == "misc_hack":

--- a/swablu/static/filter.js
+++ b/swablu/static/filter.js
@@ -22,19 +22,16 @@ function _keep(a, b) {
 function refilter() {
     // this is garbage.
     var hack_types = [
-        'balance_hack_wip', 'balance_hack_demo', 'balance_hack_mostly', 'balance_hack',
-        'story_hack_wip', 'story_hack_demo', 'story_hack_mostly', 'story_hack',
-        'translation_wip', 'translation_demo', 'translation_mostly', 'translation',
-        'misc_hack_wip', 'misc_hack_demo', 'misc_hack_mostly', 'misc_hack',
+        'balance_hack_wip', 'balance_hack_mostly', 'balance_hack',
+        'story_hack_wip', 'story_hack_mostly', 'story_hack',
+        'translation_wip', 'translation_mostly', 'translation',
+        'misc_hack_wip', 'misc_hack_mostly', 'misc_hack',
         'machinima_ongoing', 'machinima'
     ];
     
     switch (selStatus.value) {
         case "wip":
             _keep(hack_types, ['balance_hack_wip', 'story_hack_wip', 'translation_wip', 'misc_hack_wip']);
-            break;
-        case "demo":
-            _keep(hack_types, ['balance_hack_demo', 'story_hack_demo', 'translation_demo', 'misc_hack_demo', 'machinima_ongoing']);
             break;
         case "mostly":
             _keep(hack_types, ['balance_hack_mostly', 'story_hack_mostly', 'translation_mostly', 'misc_hack_mostly', 'machinima_ongoing']);
@@ -46,16 +43,16 @@ function refilter() {
     
     switch (selType.value) {
         case "balance_hack":
-            _keep(hack_types, ['balance_hack_wip', 'balance_hack_demo', 'balance_hack_mostly', 'balance_hack']);
+            _keep(hack_types, ['balance_hack_wip', 'balance_hack_mostly', 'balance_hack']);
             break;
         case "story_hack":
-            _keep(hack_types, ['story_hack_wip', 'story_hack_demo', 'story_hack_mostly', 'story_hack']);
+            _keep(hack_types, ['story_hack_wip', 'story_hack_mostly', 'story_hack']);
             break;
         case "translation":
-            _keep(hack_types, ['translation_wip', 'translation_demo', 'translation_mostly', 'translation']);
+            _keep(hack_types, ['translation_wip', 'translation_mostly', 'translation']);
             break;
         case "misc_hack":
-            _keep(hack_types, ['misc_hack_wip', 'misc_hack_demo', 'misc_hack_mostly', 'misc_hack']);
+            _keep(hack_types, ['misc_hack_wip', 'misc_hack_mostly', 'misc_hack']);
             break;
         case "machinima":
             _keep(hack_types, ['machinima_ongoing', 'machinima']);

--- a/swablu/static/filter.js
+++ b/swablu/static/filter.js
@@ -31,7 +31,7 @@ function refilter() {
     
     switch (selStatus.value) {
         case "wip":
-            _keep(hack_types, ['balance_hack_wip', 'story_hack_wip', 'translation_wip', 'misc_hack_wip']);
+            _keep(hack_types, ['balance_hack_wip', 'story_hack_wip', 'translation_wip', 'misc_hack_wip', 'machinima_ongoing']);
             break;
         case "mostly":
             _keep(hack_types, ['balance_hack_mostly', 'story_hack_mostly', 'translation_mostly', 'misc_hack_mostly', 'machinima_ongoing']);

--- a/swablu/static/styles.css
+++ b/swablu/static/styles.css
@@ -306,6 +306,11 @@ input, textarea, select, button {
     max-width: 90%;
 }
 
+input[type=checkbox] {
+  display: inline;
+  width: unset;
+}
+
 textarea {
     height: 150px;
 }

--- a/swablu/tpl/edit-form.html
+++ b/swablu/tpl/edit-form.html
@@ -2,15 +2,15 @@
 <h1>Edit ROM Hack</h1>
 {% if hack['message_id'] %}
 <div><span><em>Your hack micro page is reachable at <a href="https://skytemple.org/h/{{ hack['key'] }}">https://skytemple.org/h/{{ hack['key'] }}</a></em></span></div>
-{% else %}
+{% end %}
+{% if missing_arg %}
 <div class="red">
-    <span>You may only submit your hack if at least one of the following is true:</span>
-    <ul>
-        <li>Your ROM Hack is finished or has a playable demo.</li>
-        <li>Your ROM Hack is a machinima and has at least one episode released.</li>
-        <li>Your ROM Hack has a Discord server.</li>
-        <li>Your ROM Hack was featured in one of Parakooopa's ROM Hack Showcases.</li>
-    </ul>
+    <span>One or more required fields are missing.</span>
+</div>
+{% end %}
+{% if invalid_download_link %}
+<div class="red">
+    <span>The download link provided is invalid. Please link to the Discord attachment, not to the message.</span>
 </div>
 {% end %}
 {% if saved %}
@@ -49,8 +49,8 @@
             </select>
         </label>
         <label for="url_main">
-            Main URL*: <input name="url_main" id="url_main" placeholder="Main URL" value="{{ hack['url_main'] or '' }}"/>
-            <em>This should link to a Project Pokémon page or similar for ROM Hacks and YouTube channels for Machinimas.</em>
+            Main URL: <input name="url_main" id="url_main" placeholder="Main URL" value="{{ hack['url_main'] or '' }}"/>
+            <em>This should link to a forum post, public site or similar for ROM Hacks and YouTube channels for Machinimas.</em>
         </label>
         <label for="url_main">
             Discord URL: <input name="url_discord" id="url_discord" placeholder="Discord URL" value="{{ hack['url_discord'] or '' }}"/>
@@ -58,15 +58,15 @@
         </label>
         <label for="url_download">
             Download URL: <input name="url_download" id="url_download" placeholder="Download URL" value="{{ hack['url_download'] or '' }}"/>
-            <em>If you have a playable ROM hack, please put the download link here.</em>
+            <em>If you have a playable ROM hack, please put the download link here. You can link a Discord embed, but not a Discord message since those can't be accessed from outside the server where they were posted.</em>
         </label>
         <label for="screenshot1">
             Screenshot 1: <input name="screenshot1" id="screenshot1" type="file"/>
-            <em>Max 1MB. Should have the aspect ration of a single DS screen. If not specified the current screenshot will be kept, if there is already one.</em>
+            <em>Max 1MB. Should have the aspect ratio of a single DS screen. If not specified the current screenshot will be kept, if there is already one.</em>
         </label>
         <label for="screenshot2">
             Screenshot 2: <input name="screenshot2" id="screenshot2" type="file"/>
-            <em>Max 1MB. Should have the aspect ration of a single DS screen. If not specified the current screenshot will be kept, if there is already one.</em>
+            <em>Max 1MB. Should have the aspect ratio of a single DS screen. If not specified the current screenshot will be kept, if there is already one.</em>
         </label>
         <label for="video">
             Youtube Video: <input name="video" id="video" placeholder="YouTube URL" value="{{ hack['video'] or '' }}"/>

--- a/swablu/tpl/edit-form.html
+++ b/swablu/tpl/edit-form.html
@@ -29,19 +29,15 @@
             Hack type*:
             <select name="hack_type" id="hack_type">
               <option value="balance_hack_wip" {% if hack['hack_type'] == 'balance_hack_wip' %}selected{% end %}>Balance Hack (work in progress)</option>
-              <option value="balance_hack_demo" {% if hack['hack_type'] == 'balance_hack_demo' %}selected{% end %}>Balance Hack (with demo)</option>
               <option value="balance_hack_mostly" {% if hack['hack_type'] == 'balance_hack_mostly' %}selected{% end %}>Balance Hack (mostly finished)</option>
               <option value="balance_hack" {% if hack['hack_type'] == 'balance_hack' %}selected{% end %}>Balance Hack (finished)</option>
               <option value="story_hack_wip" {% if hack['hack_type'] == 'story_hack_wip' %}selected{% end %}>Story Hack (work in progress)</option>
-              <option value="story_hack_demo" {% if hack['hack_type'] == 'story_hack_demo' %}selected{% end %}>Story Hack (with demo)</option>
               <option value="story_hack_mostly" {% if hack['hack_type'] == 'story_hack_mostly' %}selected{% end %}>Story Hack (mostly finished)</option>
               <option value="story_hack" {% if hack['hack_type'] == 'story_hack' %}selected{% end %}>Story Hack (finished)</option>
               <option value="translation_wip" {% if hack['hack_type'] == 'translation_wip' %}selected{% end %}>Translation (work in progress)</option>
-              <option value="translation_demo" {% if hack['hack_type'] == 'translation_demo' %}selected{% end %}>Translation (with demo)</option>
               <option value="translation_mostly" {% if hack['hack_type'] == 'translation_mostly' %}selected{% end %}>Translation (mostly finished)</option>
               <option value="translation" {% if hack['hack_type'] == 'translation' %}selected{% end %}>Translation (finished)</option>
               <option value="misc_hack_wip" {% if hack['hack_type'] == 'misc_hack_wip' %}selected{% end %}>Misc. Hack (work in progress)</option>
-              <option value="misc_hack_demo" {% if hack['hack_type'] == 'misc_hack_demo' %}selected{% end %}>Misc. Hack (with demo)</option>
               <option value="misc_hack_mostly" {% if hack['hack_type'] == 'misc_hack_mostly' %}selected{% end %}>Misc. Hack (mostly finished)</option>
               <option value="misc_hack" {% if hack['hack_type'] == 'misc_hack' %}selected{% end %}>Misc. Hack (finished)</option>
               <option value="machinima_ongoing" {% if hack['hack_type'] == 'machinima_ongoing' %}selected{% end %}>Machinima (ongoing)</option>

--- a/swablu/tpl/edit-form.html
+++ b/swablu/tpl/edit-form.html
@@ -73,6 +73,12 @@
             <em>Link to a YouTube video to use as a trailer / the first episode of your machinima.</em>
         </label>
         <button type="submit">Save</button>
+        {% if hack['message_id'] %}
+        <label for="silent">Slient edit: <input name="silent" type="checkbox" id="silent">
+            <br>
+            <em>The hack's last modified date will not change.</em>
+        </label>
+        {% end %}
         <span><em>*: Required</em></span>
     </form>
 </div>

--- a/swablu/tpl/jam.html
+++ b/swablu/tpl/jam.html
@@ -8,7 +8,7 @@
         <p><strong>Gimmick: </strong>{{ jam["gimmick"] }}</p>
         {% if 'awards' in jam %}
         <div class="info">Want to find out more about why we decided how we did?
-            Ask the Jury on our <a href="https://discord.gg/skytemple>">Discord</a>! Some of the Jury members also have
+            Ask the Jury on our <a href="https://discord.gg/skytemple">Discord</a>! Some of the Jury members also have
             playthroughs on their YouTube channels.</div>
         {% end %}
     </div>

--- a/swablu/tpl/jam.html
+++ b/swablu/tpl/jam.html
@@ -4,7 +4,7 @@
 <div class="hack-listing jam-details">
     <div class="jam-description">
         <p>{{ jam ["description"] }}</p>
-        <p><strong>Motto: </strong>{{ jam["motto"] }}</p>
+        <p><strong>Theme: </strong>{{ jam["motto"] }}</p>
         <p><strong>Gimmick: </strong>{{ jam["gimmick"] }}</p>
         {% if 'awards' in jam %}
         <div class="info">Want to find out more about why we decided how we did?

--- a/swablu/tpl/list.html
+++ b/swablu/tpl/list.html
@@ -15,7 +15,7 @@
         </select></label>
         <label>Status: <select name="status">
               <option value="">---</option>
-              <option value="wip">Work in Progress</option>
+              <option value="wip">Work in Progress / Ongoing</option>
               <option value="mostly">Mostly Finished / Ongoing</option>
               <option value="finished">Finished</option>
         </select></label>

--- a/swablu/tpl/list.html
+++ b/swablu/tpl/list.html
@@ -16,7 +16,6 @@
         <label>Status: <select name="status">
               <option value="">---</option>
               <option value="wip">Work in Progress</option>
-              <option value="demo">With Demo / Ongoing</option>
               <option value="mostly">Mostly Finished / Ongoing</option>
               <option value="finished">Finished</option>
         </select></label>

--- a/swablu/web.py
+++ b/swablu/web.py
@@ -404,6 +404,9 @@ class EditFormHandler(AuthenticatedHandler):
                 break
         if key != hack_id or not hack:
             return self.redirect('/edit')
+
+        editing = bool(hack['message_id'])
+
         try:
             hack['name'] = self.get_body_argument('name')
             hack['description'] = self.get_body_argument('description')
@@ -434,7 +437,9 @@ class EditFormHandler(AuthenticatedHandler):
         if discord_writes_enabled():
             hack['message_id'] = await regenerate_message(self.discord_client, DISCORD_CHANNEL_HACKS,
                                                           int(hack['message_id']) if hack['message_id'] else None, hack)
-        update_hack(self.db, hack)
+
+        silent_edit = editing and self.get_body_argument('silent', '') != ''
+        update_hack(self.db, hack, silent_edit)
         invalidate_cache(['hack', f'hack-{hack_id}'])
         regenerate_htaccess()
         return self.redirect(f'/edit/{hack_id}?saved=1')


### PR DESCRIPTION
Some changes to the hacks website:

- Minor changes
  - Actually require required fields
  - Do not mark Main URL as required
  - Remove old hack submission requirements
  - Prevent Discord messages from being used as download links (attachments are ok)
  - Inlucde ongoing machinimas when searching for wip hacks
  - Minor text fixes
- Add an option to silently edit a hack, which does not update its modified date. Useful to fix minor mistakes without bumping the hack to the top of the list.
- Remove the "demo" category. People stated that they didn't understand the difference between that and "wip", and since having a demo is now required to upload hacks, there's no point.
  - The database needs to be updated to change all the "demo" entries to "wip" before this is deployed!

I don't know if there's a way to test this before deploying it. If so, please let me know.