### PR TITLE
Remove migrated or discontinued features

### DIFF
--- a/swablu/main.py
+++ b/swablu/main.py
@@ -42,9 +42,7 @@ async def on_ready():
 
 @discord_client.event
 async def on_member_update(before: Member, after: Member):
-    # Only first guild (SkyTemple) and second guild (DreamNexus) supported
-    if after.guild.id == DISCORD_GUILD_IDS[0]:
-        await check_for(after, get_role(after.guild, using_skytemple), skytemple_app_id)
+    # Only second guild (DreamNexus) supported
     if after.guild.id == DISCORD_GUILD_IDS[1]:
         await check_for(after, get_role(after.guild, using_dreamnexus), dreamnexus_app_id)
 
@@ -56,17 +54,9 @@ async def on_message(message: Message):
     if not discord_writes_enabled():
         return
     if message.guild.id in DISCORD_GUILD_IDS:
-        if isinstance(message.channel, TextChannel) and message.channel.name == 'welcome' and message.content == '🎉?':
-            greet_count = 0
-            async with message.channel.typing():
-                async for message in message.channel.history(limit=None):
-                    message: Message
-                    greet_count += sum([r.count for r in message.reactions if r.emoji == '🎉'])
-                await message.channel.send(f'Members have greeted {greet_count} times! 🎉')
-        else:
-            await reputation.process_cmd(message)
-            await hacks_mgmnt.process_cmd(message)
-            await general_memes.process_cmd(message)
+        await reputation.process_cmd(message)
+        await hacks_mgmnt.process_cmd(message)
+        await general_memes.process_cmd(message)
     else:
         await general_memes.process_cmd(message)
 

--- a/swablu/roles.py
+++ b/swablu/roles.py
@@ -37,11 +37,7 @@ def get_role(guild: Guild, role_name: str):
 
 async def scan_roles():
     logger.info("Periodic scan.")
-    # Only first guild (SkyTemple) and second guild (DreamNexus) supported
-    guild: Guild = discord_client.get_guild(DISCORD_GUILD_IDS[0])
-    r = get_role(guild, using_skytemple)
-    for m in guild.members:
-        await check_for(m, r, skytemple_app_id)
+    # Only second guild (DreamNexus) supported
     guild: Guild = discord_client.get_guild(DISCORD_GUILD_IDS[1])
     r = get_role(guild, using_dreamnexus)
     for m in guild.members:


### PR DESCRIPTION
In preparation for the introduction of [Altaria](https://github.com/SkyTemple/altaria), the following fieatures will be disabled, either because they have been migrated to the new bot or because they will be discontinued:

- Reputation: Migrated to Altaria (the leaderboard on the website has been replaced with a command)
- 🎉?: Requires reading too many messages
- "Using SkyTemple" role: Floods the audit log

The features remaining in Swablu will be related to the website and hack management. Ideally, those would be rewritten at some point so a Discord bot isn't required to view and manage the site, but that's out of the scope of this migration.