### PR TITLE
Invalidate hack cache when updating a jam

### DIFF
--- a/swablu/specific/hacks_mgmnt.py
+++ b/swablu/specific/hacks_mgmnt.py
@@ -9,7 +9,7 @@ from swablu.util import MiniCtx
 from swablu.config import database, TABLE_NAME, discord_client, discord_writes_enabled, get_jam, get_rom_hacks, \
     jam_exists, update_jam, create_jam, db_cursor, DISCORD_CHANNEL_HACKS
 from swablu.discord_util import regenerate_message
-from swablu.web import invalidate_cache
+from swablu.web import invalidate_cache, invalidate_jam_cache
 
 ALLOWED_ROLES = [
     712704493661192275,  # Admin
@@ -99,7 +99,7 @@ async def process_create_jam(message: Message, channel: TextChannel):
         raise ValueError("This jam already exists. Use !update_jam.")
 
     create_jam(database, jam_key, jam_data)
-    invalidate_cache(f'jam-{jam_key}')
+    invalidate_jam_cache(jam_key, jam_data)
     await channel.send("OK")
 
 
@@ -116,7 +116,7 @@ async def process_update_jam(message: Message, channel: TextChannel):
         raise ValueError("This jam does not exist. Use !create_jam.")
 
     update_jam(database, jam_key, jam_data)
-    invalidate_cache(f'jam-{jam_key}')
+    invalidate_jam_cache(jam_key, jam_data)
     await channel.send("OK")
 
 

--- a/swablu/web.py
+++ b/swablu/web.py
@@ -57,6 +57,17 @@ def invalidate_cache(cache_tags):
     else:
         logger.info(f'Cleared cache ({cache_tags})')
 
+
+def invalidate_jam_cache(jam_key: str, jam_data: str):
+    tags_to_purge = [f'jam-{jam_key}']
+
+    jam_data_json = json.loads(jam_data)
+    for hack in jam_data_json["hacks"]:
+        tags_to_purge.append(f'hack-{hack}')
+
+    invalidate_cache(tags_to_purge)
+
+
 class SessionTokenProvider:
     tokens = {}
 


### PR DESCRIPTION
Properly invalidates the cache for hack jams when the jam is updated. Fixes #21.